### PR TITLE
Uodate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a skeleton.
 
 This project builds upon Agent C Framework and provides additional utilities and reference implementations. Follow these instructions to get started with development.
 
+**Note:** The branch `reference` has been set aside to serve as a reference starting point for people working with local/private copies of the Agent C source.
+
 ## Prerequisites
 
 - **Python 3.10+**: This project requires Python 3.10 or newer. [Download Python](https://www.python.org/downloads/)


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a note about the `reference` branch serving as a starting point for people working with local/private copies of the Agent C source.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R8): Added a note about the `reference` branch serving as a reference starting point for local/private copies of the Agent C source.